### PR TITLE
Minor widget bug fixes

### DIFF
--- a/tawk_to/src/Controller/TawktoController.php
+++ b/tawk_to/src/Controller/TawktoController.php
@@ -19,7 +19,7 @@ class TawktoController extends ControllerBase
     }
 
     public function admin()
-    {   
+    {
         $widget = $this->generator->widget();
         $this->loggerFactory->get('default')->debug($widget);
 

--- a/tawk_to/src/core/TawktoGenerator.php
+++ b/tawk_to/src/core/TawktoGenerator.php
@@ -18,10 +18,10 @@ class TawktoGenerator
         // // Page title and source text.
         // $page_id = $config->get('tawk_to.page_id');
         // $widget_id = $config->get('tawk_to.widget_id');
-        
+
         return $this->getWidget();
     }
-    
+
 
     /**
      * Return widget details from the database.
@@ -33,7 +33,7 @@ class TawktoGenerator
         if (!$page_id || !$widget_id) {
             return '';
         }
-        
+
         $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
         if ($user) {
             $username = $user->get('name')->value;
@@ -79,13 +79,15 @@ class TawktoGenerator
      */
     public function getIframeUrl()
     {
-      if (!$widget = $this->getWidgetVars()) {
-        $widget = array(
+        $widget = $this->getWidgetVars();
+        extract($widget);
+        if (!$page_id || !$widget_id) {
+            $widget = array(
                 'page_id'   => '',
                 'widget_id' => '',
             );
-      }
-      return $this->getBaseUrl() . '/generic/widgets?currentWidgetId=' . $widget['widget_id'] . '&currentPageId=' . $widget['page_id'];
+        }
+        return $this->getBaseUrl() . '/generic/widgets?currentWidgetId=' . $widget['widget_id'] . '&currentPageId=' . $widget['page_id'];
     }
 
     /**
@@ -145,7 +147,7 @@ class TawktoGenerator
                                         }
                                     }
                                     ?>
-                                    <input type="checkbox" class="col-lg-6" name="always_display" id="always_display" value="1" 
+                                    <input type="checkbox" class="col-lg-6" name="always_display" id="always_display" value="1"
                                         <?php echo ($checked)?'checked':'';?> />
                                 </div>
                             </div>
@@ -155,7 +157,7 @@ class TawktoGenerator
                                 <div class="col-lg-6 control-label">
                                     <?php if (!empty($display_opts->hide_oncustom)) : ?>
                                         <?php $whitelist = json_decode($display_opts->hide_oncustom) ?>
-                                        <textarea class="form-control hide_specific" name="hide_oncustom" 
+                                        <textarea class="form-control hide_specific" name="hide_oncustom"
                                             id="hide_oncustom" cols="30" rows="10"><?php foreach ($whitelist as $page) { echo $page."\r\n"; } ?></textarea>
                                     <?php else : ?>
                                         <textarea class="form-control hide_specific" name="hide_oncustom" id="hide_oncustom" cols="30" rows="10"></textarea>
@@ -179,12 +181,12 @@ class TawktoGenerator
                                         }
                                     }
                                     ?>
-                                    <input type="checkbox" class="col-lg-6 show_specific" name="show_onfrontpage" 
-                                        id="show_onfrontpage" value="1" 
+                                    <input type="checkbox" class="col-lg-6 show_specific" name="show_onfrontpage"
+                                        id="show_onfrontpage" value="1"
                                         <?php echo ($checked)?'checked':'';?> />
                                 </div>
                             </div>
-                            
+
                             <div class="form-group col-lg-12">
                                 <label for="show_oncategory" class="col-lg-6 control-label">Show on category pages</label>
                                 <div class="col-lg-6 control-label ">
@@ -196,17 +198,17 @@ class TawktoGenerator
                                         }
                                     }
                                     ?>
-                                    <input type="checkbox" class="col-lg-6 show_specific" name="show_oncategory" id="show_oncategory" value="1" 
+                                    <input type="checkbox" class="col-lg-6 show_specific" name="show_oncategory" id="show_oncategory" value="1"
                                         <?php echo ($checked)?'checked':'';?>  />
                                 </div>
                             </div>
-                            
+
                             <div class="form-group col-lg-12">
                                 <label for="show_oncustom" class="col-lg-6 control-label">Show on pages:</label>
                                 <div class="col-lg-6 control-label">
                                     <?php if (isset($display_opts->show_oncustom) && !empty($display_opts->show_oncustom)) : ?>
                                         <?php $whitelist = json_decode($display_opts->show_oncustom) ?>
-                                        <textarea class="form-control show_specific" name="show_oncustom" id="show_oncustom" cols="30" 
+                                        <textarea class="form-control show_specific" name="show_oncustom" id="show_oncustom" cols="30"
                                             rows="10"><?php foreach ($whitelist as $page) { echo $page."\r\n"; } ?></textarea>
                                     <?php else : ?>
                                         <textarea class="form-control show_specific" name="show_oncustom" id="show_oncustom" cols="30" rows="10"></textarea>
@@ -223,11 +225,11 @@ class TawktoGenerator
                             <div id="optionsSuccessMessage" style="position:absolute;top:0;left;0;background-color: #dff0d8; color: #3c763d; border-color: #d6e9c6; font-weight: bold; display: none;" class="alert alert-success col-lg-5">Successfully set widget options to your site</div>
                             <label for="show_oncustom" class="col-lg-6 control-label"></label>
                             <div class="form-group">
-                                <button type="submit" value="1" id="module_form_submit_btn" name="submitBlockCategories" class="btn btn-default pull-right"><i class="process-icon-save"></i> Save</button>    
+                                <button type="submit" value="1" id="module_form_submit_btn" name="submitBlockCategories" class="btn btn-default pull-right"><i class="process-icon-save"></i> Save</button>
                             </div>
                         </div>
                     </form>
-                    
+
                 </div>
                 <div class="col-lg-4"></div>
             </div>
@@ -344,7 +346,7 @@ class TawktoGenerator
             return new JsonResponse($options);
         }
 
-        if (preg_match('/^[0-9A-Fa-f]{24}$/', $page) !== 1 
+        if (preg_match('/^[0-9A-Fa-f]{24}$/', $page) !== 1
             || preg_match('/^[a-z0-9]{1,50}$/i', $widget) !== 1) {
             return new JsonResponse($options);
         }
@@ -355,7 +357,7 @@ class TawktoGenerator
         $config->set('tawk_to.widget_id', $widget);
         $config->set('tawk_to.user_id', \Drupal::currentUser()->id());
         // $config->set('tawk_to.options', $options);
-        // 
+        //
         $config->save();
 
         // \Drupal::state()->set(TAWK_TO_WIDGET_PID, $page);
@@ -405,7 +407,7 @@ class TawktoGenerator
                     $value = (empty($value)||!$value)?array():$value;
                     $jsonOpts[$column] = json_encode($value);
                     break;
-                
+
                 case 'show_onfrontpage':
                 case 'show_oncategory':
                 case 'always_display':

--- a/tawk_to/src/core/TawktoGenerator.php
+++ b/tawk_to/src/core/TawktoGenerator.php
@@ -372,9 +372,9 @@ class TawktoGenerator
         $config = \Drupal::service('config.factory')->getEditable('tawk_to.settings');
         $config->set('tawk_to.page_id', 0);
         $config->set('tawk_to.widget_id', 0);
-        $config->set('tawk_to.user_id', 0);
+        $config->set('tawk_to.user_id', null);
         // $config->set('tawk_to.options', 0);
-        
+
         $config->save();
 
         $options = array('success' => true);

--- a/tawk_to/src/core/TawktoGenerator.php
+++ b/tawk_to/src/core/TawktoGenerator.php
@@ -13,12 +13,6 @@ class TawktoGenerator
 {
     public function widget()
     {
-        // // Default settings.
-        // $config = \Drupal::config('tawk_to.settings');
-        // // Page title and source text.
-        // $page_id = $config->get('tawk_to.page_id');
-        // $widget_id = $config->get('tawk_to.widget_id');
-
         return $this->getWidget();
     }
 
@@ -105,7 +99,6 @@ class TawktoGenerator
         $vars = $this->getWidgetVars();
         extract($vars);
 
-        // $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
         $sameUser = false;
         if (is_null($user_id) || \Drupal::currentUser()->id()==$user_id) {
             $sameUser = true;
@@ -323,10 +316,6 @@ class TawktoGenerator
 
     public function getWidgetVars()
     {
-        // return array(
-        //         'page_id' => \Drupal::state()->get(TAWK_TO_WIDGET_PID),
-        //         'widget_id' => \Drupal::state()->get(TAWK_TO_WIDGET_WID),
-        //     );
         $config = \Drupal::service('config.factory')->getEditable('tawk_to.settings');
         return array(
                 'page_id' => $config->get('tawk_to.page_id'),
@@ -351,17 +340,11 @@ class TawktoGenerator
             return new JsonResponse($options);
         }
 
-        // $config = $this->config('tawk_to.settings');
         $config = \Drupal::service('config.factory')->getEditable('tawk_to.settings');
         $config->set('tawk_to.page_id', $page);
         $config->set('tawk_to.widget_id', $widget);
         $config->set('tawk_to.user_id', \Drupal::currentUser()->id());
-        // $config->set('tawk_to.options', $options);
-        //
         $config->save();
-
-        // \Drupal::state()->set(TAWK_TO_WIDGET_PID, $page);
-        // \Drupal::state()->set(TAWK_TO_WIDGET_WID, $widget);
 
         $options = array('success' => true);
         return new JsonResponse($options);
@@ -373,7 +356,6 @@ class TawktoGenerator
         $config->set('tawk_to.page_id', 0);
         $config->set('tawk_to.widget_id', 0);
         $config->set('tawk_to.user_id', null);
-        // $config->set('tawk_to.options', 0);
 
         $config->save();
 
@@ -411,7 +393,6 @@ class TawktoGenerator
                 case 'show_onfrontpage':
                 case 'show_oncategory':
                 case 'always_display':
-                // default:
                     $jsonOpts[$column] = ($value==1)?true:false;
                     break;
             }

--- a/tawk_to/tawk_to.module
+++ b/tawk_to/tawk_to.module
@@ -42,95 +42,12 @@ function tawk_to_page_bottom(array &$page_bottom)
     if (!$is_admin) {
         $generator = new TawktoGenerator;
 
-        // get visibility options
-        $vars = $generator->getWidgetVars();
-        extract($vars);
-        if ($options && !is_null($options)) {
-            global $base_url;
-            // $current_uri = \Drupal::request()->getRequestUri();
-
-            $options = json_decode($options);
-
-            // prepare visibility
-            $currentUrl = $base_url.$_SERVER["REQUEST_URI"];
-            if (false==$options->always_display) {
-
-                $showPages = json_decode($options->show_oncustom);
-                $show = false;
-                foreach ($showPages as $slug) {
-                    if (empty(trim($slug))) {
-                        continue;
-                    }
-
-                    // if (stripos($currentUrl, $slug)!==false) {
-                    if ($currentUrl == $slug) {
-                        $show = true;
-                        break;
-                    }
-                }
-
-                // check if category/taxonomy page
-                // taxonomy page
-                if ("taxonomy_term" == strtolower(\Drupal::request()->attributes->get('view_id'))) {
-                    if (false != $options->show_oncategory) {
-                        $show = true;
-                    }
-                }
-
-                // check if frontpage
-                if (\Drupal::service('path.matcher')->isFrontPage()) {
-                    if (false != $options->show_onfrontpage) {
-                        $show = true;
-                    }
-                }
-
-                // taxonomy page
-                // code below is deprecated in Drupal 8
-                // if (arg(0) ==  "taxonomy" && arg(1) == "term" && is_numeric(arg(2)) && arg(3) == "") {
-                //     if (false==$options->show_oncategory) {
-                //         return;
-                //     }
-                // }
-                // $current_path = \Drupal::service('path.current')->getPath();
-                // $path_args = explode('/', $current_path);
-
-                if (!$show) {
-                    return;
-                }
-            } else {
-                $hide_pages = json_decode($options->hide_oncustom);
-                $show = true;
-
-                // $currentUrl = urlencode($current_page);
-                $currentUrl = (string) $currentUrl;
-                foreach ($hide_pages as $slug) {
-
-                    if (empty(trim($slug))) {
-                        continue;
-                    }
-
-                    $slug = (string) htmlspecialchars($slug); // we need to add htmlspecialchars due to slashes added when saving to database
-
-                    // if (stripos($currentUrl, $slug)!==false) {
-                    if ($currentUrl == $slug) {
-                        $show = false;
-                        break;
-                    }
-                }
-
-                if (!$show) {
-                    return;
-                }
-            }
-        }
-
         $page_bottom['tawk_to'] = array(
             '#type' => 'inline_template',
-            '#template' => $generator->widget()
+            '#template' => $generator->widget(),
+            '#cache' => array(
+                'tags' => array('tawk_widget')
+            )
         );
-
-        $config = \Drupal::service('config.factory')->getEditable('tawk_to.settings');
-        $renderer = \Drupal::service('renderer');
-        $renderer->addCacheableDependency($page_bottom['tawk_to'], $config);
     }
 }

--- a/tawk_to/tawk_to.module
+++ b/tawk_to/tawk_to.module
@@ -41,16 +41,16 @@ function tawk_to_page_bottom(array &$page_bottom)
     $is_admin = ($is_admin_route || $has_node_operation_option);
     if (!$is_admin) {
         $generator = new TawktoGenerator;
-        
+
         // get visibility options
         $vars = $generator->getWidgetVars();
         extract($vars);
         if ($options && !is_null($options)) {
             global $base_url;
             // $current_uri = \Drupal::request()->getRequestUri();
-            
+
             $options = json_decode($options);
-            
+
             // prepare visibility
             $currentUrl = $base_url.$_SERVER["REQUEST_URI"];
             if (false==$options->always_display) {
@@ -81,9 +81,9 @@ function tawk_to_page_bottom(array &$page_bottom)
                 if (\Drupal::service('path.matcher')->isFrontPage()) {
                     if (false != $options->show_onfrontpage) {
                         $show = true;
-                    }                
+                    }
                 }
-                
+
                 // taxonomy page
                 // code below is deprecated in Drupal 8
                 // if (arg(0) ==  "taxonomy" && arg(1) == "term" && is_numeric(arg(2)) && arg(3) == "") {
@@ -93,14 +93,14 @@ function tawk_to_page_bottom(array &$page_bottom)
                 // }
                 // $current_path = \Drupal::service('path.current')->getPath();
                 // $path_args = explode('/', $current_path);
-                
+
                 if (!$show) {
                     return;
                 }
             } else {
                 $hide_pages = json_decode($options->hide_oncustom);
                 $show = true;
-                
+
                 // $currentUrl = urlencode($current_page);
                 $currentUrl = (string) $currentUrl;
                 foreach ($hide_pages as $slug) {
@@ -108,16 +108,16 @@ function tawk_to_page_bottom(array &$page_bottom)
                     if (empty(trim($slug))) {
                         continue;
                     }
-                    
+
                     $slug = (string) htmlspecialchars($slug); // we need to add htmlspecialchars due to slashes added when saving to database
-                    
+
                     // if (stripos($currentUrl, $slug)!==false) {
                     if ($currentUrl == $slug) {
                         $show = false;
                         break;
                     }
                 }
-                
+
                 if (!$show) {
                     return;
                 }
@@ -125,8 +125,12 @@ function tawk_to_page_bottom(array &$page_bottom)
         }
 
         $page_bottom['tawk_to'] = array(
-                '#type' => 'inline_template',
-                '#template' => $generator->widget()
-            );
+            '#type' => 'inline_template',
+            '#template' => $generator->widget()
+        );
+
+        $config = \Drupal::service('config.factory')->getEditable('tawk_to.settings');
+        $renderer = \Drupal::service('renderer');
+        $renderer->addCacheableDependency($page_bottom['tawk_to'], $config);
     }
 }


### PR DESCRIPTION
Fixed the following bugs encountered:
- Widget still loads even after removing it from the configuration page.
- Widget isn't loading in the pages that end with `/` or `/en`.
- Configuration page `another user set the widget` alert shows after removing the widget and refreshing the configuration page.

The changes here were cherry-picked from the PR https://github.com/tawk/tawk-drupal8/pull/1. The PR was closed due to me resetting the source branch (master branch of my forked repo) to match this repo's master branch.